### PR TITLE
Fixed URL used for authentication doc example

### DIFF
--- a/api_documentation/overview.md
+++ b/api_documentation/overview.md
@@ -118,7 +118,7 @@ There are several ways to authenticate to the API. All requests to the API requi
 ### OAuth 2 Token (sent in a header)
 
 <span class="url">
-  curl -H "Authorization: Bearer OAUTH-TOKEN" https://monicahq.com/api
+  curl -H "Authorization: Bearer OAUTH-TOKEN" https://app.monicahq.com/api
 </span>
 
 <a id="markdown-oauth2-keysecret" name="oauth2-keysecret"></a>


### PR DESCRIPTION
The URL `https://monicahq.com/api` doesn't work for me in the auth example. The text above mentions the correct URL (`https://app.monicahq.com/api`).